### PR TITLE
Lua version 5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
     "targetPath": "lib",
 
     "dependencies": {
-        "derelict-util": ">=1.0.3"
+        "derelict-util": ">=1.9.1"
     }
 }

--- a/source/derelict/lua/functions.d
+++ b/source/derelict/lua/functions.d
@@ -43,9 +43,6 @@ extern( C ) @nogc nothrow {
     alias da_lua_gettop = int function( lua_State* );
     alias da_lua_settop = void function( lua_State*, int );
     alias da_lua_pushvalue = void function( lua_State*, int );
-    alias da_lua_remove = void function( lua_State*, int );
-    alias da_lua_insert = void function( lua_State*, int );
-    alias da_lua_replace = void function( lua_State*, int );
     alias da_lua_copy = void function( lua_State*, int, int );
     alias da_lua_checkstack = int function( lua_State*, int sz );
     alias da_lua_xmove = void function( lua_State*, lua_State*, int );
@@ -57,7 +54,6 @@ extern( C ) @nogc nothrow {
     alias da_lua_typename = const( char )* function( lua_State*, int );
     alias da_lua_tonumberx = lua_Number function( lua_State*, int, int* );
     alias da_lua_tointegerx = lua_Integer function( lua_State*, int, int* );
-    alias da_lua_tounsignedx = lua_Unsigned function( lua_State*, int, int* );
     alias da_lua_toboolean = int function( lua_State*, int );
     alias da_lua_tolstring = const( char )* function( lua_State*, int, size_t* );
     alias da_lua_rawlen = size_t function( lua_State*, int );
@@ -71,7 +67,6 @@ extern( C ) @nogc nothrow {
     alias da_lua_pushnil = void function( lua_State* );
     alias da_lua_pushnumber = void function( lua_State*, lua_Number );
     alias da_lua_pushinteger = void function( lua_State*, lua_Integer );
-    alias da_lua_pushunsigned = void function( lua_State*, lua_Unsigned );
     alias da_lua_pushlstring = const( char )* function( lua_State*, const( char )*, size_t );
     alias da_lua_pushstring = const( char )* function( lua_State*, const( char )* );
     alias da_lua_pushvfstring = const( char )* function( lua_State*, const( char )*, va_list );
@@ -98,12 +93,11 @@ extern( C ) @nogc nothrow {
     alias da_lua_rawsetp = void function( lua_State*, int, const( void )* );
     alias da_lua_setmetatable = int function( lua_State*, int );
     alias da_lua_setuservalue = void function( lua_State*, int );
-    alias da_lua_callk = void function( lua_State*, int, int, int, lua_CFunction );
-    alias da_lua_getctx = int function( lua_State*, int* );
-    alias da_lua_pcallk = int function( lua_State*, int, int, int, int, lua_CFunction );
+    alias da_lua_callk = void function( lua_State*, int, int, lua_KContext , lua_KFunction );
+    alias da_lua_pcallk = int function( lua_State*, int, int, int, lua_KContext, lua_KFunction );
     alias da_lua_load = int function( lua_State*, lua_Reader, void*, const( char )*, const( char )* );
-    alias da_lua_dump = int function( lua_State*, lua_Writer, void* );
-    alias da_lua_yieldk = int function( lua_State*, int, int, lua_CFunction );
+    alias da_lua_dump = int function( lua_State*, lua_Writer, void*, int );
+    alias da_lua_yieldk = int function( lua_State*, int, lua_KContext, lua_KFunction );
     alias da_lua_resume = int function( lua_State*, lua_State*, int );
     alias da_lua_status = int function( lua_State* );
     alias da_lua_gc = int function( lua_State*, int, int );
@@ -125,9 +119,10 @@ extern( C ) @nogc nothrow {
     alias da_lua_gethook = lua_Hook function( lua_State* );
     alias da_lua_gethookmask = int function( lua_State* );
     alias da_lua_gethookcount = int function( lua_State* );
+    alias da_lua_rotate = void function( lua_State*, int, int );
 
     //lauxlib.h
-    alias da_luaL_checkversion_ = void function( lua_State*, lua_Number );
+    alias da_luaL_checkversion_ = void function( lua_State*, lua_Number, size_t );
     alias da_luaL_getmetafield = int function( lua_State*, int, const( char )* );
     alias da_luaL_callmeta = int function( lua_State*, int, const( char )* );
     alias da_luaL_tolstring = const( char )* function( lua_State*, int, size_t* );
@@ -138,8 +133,6 @@ extern( C ) @nogc nothrow {
     alias da_luaL_optnumber = lua_Number function( lua_State*, int, lua_Number );
     alias da_luaL_checkinteger = lua_Integer function( lua_State*, int );
     alias da_luaL_optinteger = lua_Integer function( lua_State*, int, lua_Integer );
-    alias da_luaL_checkunsigned = lua_Unsigned function( lua_State*, int );
-    alias da_luaL_optunsigned = lua_Unsigned function( lua_State*, int, lua_Unsigned );
     alias da_luaL_checkstack = void function( lua_State*, int, const( char )* );
     alias da_luaL_checktype = void function( lua_State*, int, int );
     alias da_luaL_checkany = void function( lua_State*, int );
@@ -172,8 +165,6 @@ extern( C ) @nogc nothrow {
     alias da_luaL_pushresult = void function( luaL_Buffer* );
     alias da_luaL_pushresultsize = void function( luaL_Buffer*, size_t );
     alias da_luaL_buffinitsize = char* function( lua_State*, luaL_Buffer*, size_t );
-    alias da_luaL_pushmodule = void function( lua_State*, const( char )*, int );
-    alias da_luaL_openlib = void function( lua_State*, const( char )*, const( luaL_Reg )*, int );
     //lualib.h
     alias da_luaopen_base = int function( lua_State* );
     alias da_luaopen_coroutine = int function( lua_State* );
@@ -182,6 +173,7 @@ extern( C ) @nogc nothrow {
     alias da_luaopen_os = int function( lua_State* );
     alias da_luaopen_string = int function( lua_State* );
     alias da_luaopen_bit32 = int function( lua_State* );
+    alias da_luaopen_utf8 = int function( lua_State* );
     alias da_luaopen_math = int function( lua_State* );
     alias da_luaopen_debug = int function( lua_State* );
     alias da_luaopen_package = int function( lua_State* );
@@ -198,9 +190,6 @@ __gshared {
     da_lua_gettop lua_gettop;
     da_lua_settop lua_settop;
     da_lua_pushvalue lua_pushvalue;
-    da_lua_remove lua_remove;
-    da_lua_insert lua_insert;
-    da_lua_replace lua_replace;
     da_lua_copy lua_copy;
     da_lua_checkstack lua_checkstack;
     da_lua_xmove lua_xmove;
@@ -212,7 +201,6 @@ __gshared {
     da_lua_typename lua_typename;
     da_lua_tonumberx lua_tonumberx;
     da_lua_tointegerx lua_tointegerx;
-    da_lua_tounsignedx lua_tounsignedx;
     da_lua_toboolean lua_toboolean;
     da_lua_tolstring lua_tolstring;
     da_lua_rawlen lua_rawlen;
@@ -226,7 +214,6 @@ __gshared {
     da_lua_pushnil lua_pushnil;
     da_lua_pushnumber lua_pushnumber;
     da_lua_pushinteger lua_pushinteger;
-    da_lua_pushunsigned lua_pushunsigned;
     da_lua_pushlstring lua_pushlstring;
     da_lua_pushstring lua_pushstring;
     da_lua_pushvfstring lua_pushvfstring;
@@ -254,7 +241,6 @@ __gshared {
     da_lua_setmetatable lua_setmetatable;
     da_lua_setuservalue lua_setuservalue;
     da_lua_callk lua_callk;
-    da_lua_getctx lua_getctx;
     da_lua_pcallk lua_pcallk;
     da_lua_load lua_load;
     da_lua_dump lua_dump;
@@ -280,6 +266,7 @@ __gshared {
     da_lua_gethook lua_gethook;
     da_lua_gethookmask lua_gethookmask;
     da_lua_gethookcount lua_gethookcount;
+    da_lua_rotate lua_rotate;
     da_luaL_checkversion_ luaL_checkversion_;
     da_luaL_getmetafield luaL_getmetafield;
     da_luaL_callmeta luaL_callmeta;
@@ -291,8 +278,6 @@ __gshared {
     da_luaL_optnumber luaL_optnumber;
     da_luaL_checkinteger luaL_checkinteger;
     da_luaL_optinteger luaL_optinteger;
-    da_luaL_checkunsigned luaL_checkunsigned;
-    da_luaL_optunsigned luaL_optunsigned;
     da_luaL_checkstack luaL_checkstack;
     da_luaL_checktype luaL_checktype;
     da_luaL_checkany luaL_checkany;
@@ -325,8 +310,6 @@ __gshared {
     da_luaL_pushresult luaL_pushresult;
     da_luaL_pushresultsize luaL_pushresultsize;
     da_luaL_buffinitsize luaL_buffinitsize;
-    da_luaL_pushmodule luaL_pushmodule;
-    da_luaL_openlib luaL_openlib;
     da_luaopen_base luaopen_base;
     da_luaopen_coroutine luaopen_coroutine;
     da_luaopen_table luaopen_table;
@@ -334,6 +317,7 @@ __gshared {
     da_luaopen_os luaopen_os;
     da_luaopen_string luaopen_string;
     da_luaopen_bit32 luaopen_bit32;
+    da_luaopen_utf8 luaopen_utf8;
     da_luaopen_math luaopen_math;
     da_luaopen_debug luaopen_debug;
     da_luaopen_package luaopen_package;

--- a/source/derelict/lua/lua.d
+++ b/source/derelict/lua/lua.d
@@ -38,9 +38,9 @@ private {
     import derelict.util.system;
 
     static if( Derelict_OS_Windows ) {
-        enum libNames = "lua52.dll";
+        enum libNames = "lua53.dll";
     } else static if( Derelict_OS_Posix ) {
-        enum libNames = "liblua5.2.so";
+        enum libNames = "liblua5.3.so";
     }
     else
         static assert( 0, "Need to implement lua libNames for this operating system." );
@@ -61,9 +61,6 @@ class DerelictLuaLoader : SharedLibLoader {
         bindFunc( cast( void** )&lua_gettop, "lua_gettop" );
         bindFunc( cast( void** )&lua_settop, "lua_settop" );
         bindFunc( cast( void** )&lua_pushvalue, "lua_pushvalue" );
-        bindFunc( cast( void** )&lua_remove, "lua_remove" );
-        bindFunc( cast( void** )&lua_insert, "lua_insert" );
-        bindFunc( cast( void** )&lua_replace, "lua_replace" );
         bindFunc( cast( void** )&lua_copy, "lua_copy" );
         bindFunc( cast( void** )&lua_checkstack, "lua_checkstack" );
         bindFunc( cast( void** )&lua_xmove, "lua_xmove" );
@@ -76,7 +73,6 @@ class DerelictLuaLoader : SharedLibLoader {
         bindFunc( cast( void** )&lua_typename, "lua_typename" );
         bindFunc( cast( void** )&lua_tonumberx, "lua_tonumberx" );
         bindFunc( cast( void** )&lua_tointegerx, "lua_tointegerx" );
-        bindFunc( cast( void** )&lua_tounsignedx, "lua_tounsignedx" );
         bindFunc( cast( void** )&lua_toboolean, "lua_toboolean" );
         bindFunc( cast( void** )&lua_tolstring, "lua_tolstring" );
         bindFunc( cast( void** )&lua_rawlen, "lua_rawlen" );
@@ -90,7 +86,6 @@ class DerelictLuaLoader : SharedLibLoader {
         bindFunc( cast( void** )&lua_pushnil, "lua_pushnil" );
         bindFunc( cast( void** )&lua_pushnumber, "lua_pushnumber" );
         bindFunc( cast( void** )&lua_pushinteger, "lua_pushinteger" );
-        bindFunc( cast( void** )&lua_pushunsigned, "lua_pushunsigned" );
         bindFunc( cast( void** )&lua_pushlstring, "lua_pushlstring" );
         bindFunc( cast( void** )&lua_pushstring, "lua_pushstring" );
         bindFunc( cast( void** )&lua_pushvfstring, "lua_pushvfstring" );
@@ -117,7 +112,6 @@ class DerelictLuaLoader : SharedLibLoader {
         bindFunc( cast( void** )&lua_setmetatable, "lua_setmetatable" );
         bindFunc( cast( void** )&lua_setuservalue, "lua_setuservalue" );
         bindFunc( cast( void** )&lua_callk, "lua_callk" );
-        bindFunc( cast( void** )&lua_getctx, "lua_getctx" );
         bindFunc( cast( void** )&lua_pcallk, "lua_pcallk" );
         bindFunc( cast( void** )&lua_load, "lua_load" );
         bindFunc( cast( void** )&lua_dump, "lua_dump" );
@@ -142,6 +136,7 @@ class DerelictLuaLoader : SharedLibLoader {
         bindFunc( cast( void** )&lua_gethook, "lua_gethook" );
         bindFunc( cast( void** )&lua_gethookmask, "lua_gethookmask" );
         bindFunc( cast( void** )&lua_gethookcount, "lua_gethookcount" );
+        bindFunc( cast( void** )&lua_rotate, "lua_rotate" );
         bindFunc( cast( void** )&luaL_checkversion_, "luaL_checkversion_" );
         bindFunc( cast( void** )&luaL_getmetafield, "luaL_getmetafield" );
         bindFunc( cast( void** )&luaL_callmeta, "luaL_callmeta" );
@@ -153,8 +148,6 @@ class DerelictLuaLoader : SharedLibLoader {
         bindFunc( cast( void** )&luaL_optnumber, "luaL_optnumber" );
         bindFunc( cast( void** )&luaL_checkinteger, "luaL_checkinteger" );
         bindFunc( cast( void** )&luaL_optinteger, "luaL_optinteger" );
-        bindFunc( cast( void** )&luaL_checkunsigned, "luaL_checkunsigned" );
-        bindFunc( cast( void** )&luaL_optunsigned, "luaL_optunsigned" );
         bindFunc( cast( void** )&luaL_checkstack, "luaL_checkstack" );
         bindFunc( cast( void** )&luaL_checktype, "luaL_checktype" );
         bindFunc( cast( void** )&luaL_checkany, "luaL_checkany" );
@@ -187,14 +180,13 @@ class DerelictLuaLoader : SharedLibLoader {
         bindFunc( cast( void** )&luaL_pushresult, "luaL_pushresult" );
         bindFunc( cast( void** )&luaL_pushresultsize, "luaL_pushresultsize" );
         bindFunc( cast( void** )&luaL_buffinitsize, "luaL_buffinitsize" );
-        bindFunc( cast( void** )&luaL_pushmodule, "luaL_pushmodule" );
-        bindFunc( cast( void** )&luaL_openlib, "luaL_openlib" );
         bindFunc( cast( void** )&luaopen_base, "luaopen_base" );
         bindFunc( cast( void** )&luaopen_coroutine, "luaopen_coroutine" );
         bindFunc( cast( void** )&luaopen_table, "luaopen_table" );
         bindFunc( cast( void** )&luaopen_io, "luaopen_io" );
         bindFunc( cast( void** )&luaopen_os, "luaopen_os" );
         bindFunc( cast( void** )&luaopen_string, "luaopen_string" );
+        bindFunc( cast( void** )&luaopen_utf8, "luaopen_utf8" );
         bindFunc( cast( void** )&luaopen_bit32, "luaopen_bit32" );
         bindFunc( cast( void** )&luaopen_math, "luaopen_math" );
         bindFunc( cast( void** )&luaopen_debug, "luaopen_debug" );

--- a/source/derelict/lua/macros.d
+++ b/source/derelict/lua/macros.d
@@ -50,9 +50,6 @@ lua_Number lua_tonumber( lua_State* L, int i ) {
 lua_Integer lua_tointeger( lua_State* L, int i ) {
     return lua_tointegerx( L, i, null );
 }
-lua_Unsigned lua_tounsigned( lua_State* L, int i ) {
-    return lua_tounsignedx( L, i, null );
-}
 
 void lua_pop( lua_State* L, int idx ) {
     lua_settop( L, ( -idx )-1 );
@@ -103,9 +100,23 @@ void lua_pushglobaltable( lua_State* L ) {
 const( char )* lua_tostring( lua_State* L, int idx ) {
     return lua_tolstring( L, idx, null );
 }
+
+void lua_insert( lua_State* L, int idx ) {
+    lua_rotate( L, idx, 1 );
+}
+
+void lua_remove( lua_State* L, int idx ) {
+    lua_rotate( L, idx, -1 );
+    lua_pop( L, 1 );
+}
+
+void lua_replace( lua_State* L, int idx ) {
+    lua_copy( L, -1, idx );
+    lua_pop( L, 1 );
+}
 //lauxlib.h
 void luaL_checkversion( lua_State* L ) {
-    luaL_checkversion_( L, LUA_VERSION_NUM );
+    luaL_checkversion_( L, LUA_VERSION_NUM, lua_Integer.sizeof * 16 + lua_Number.sizeof );
 }
 int luaL_loadfile( lua_State* L, const( char )* f ) {
     return luaL_loadfilex( L, f, null );
@@ -115,6 +126,7 @@ void luaL_newlibtable( lua_State* L, const( luaL_Reg )[] l ) {
     lua_createtable( L, 0, cast( int )( l.length ) - 1 );
 }
 void luaL_newlib( lua_State* L, luaL_Reg[] l ) {
+    luaL_checkversion( L );
     luaL_newlibtable( L, l );
     luaL_setfuncs( L, l.ptr, 0 );
 }
@@ -126,18 +138,6 @@ const( char )* luaL_checkstring( lua_State* L, int n ) {
 }
 const( char )* luaL_optstring( lua_State* L, int n, const( char )* d ) {
     return luaL_optlstring( L, n, d, null );
-}
-int luaL_checkint( lua_State* L, int n ){
-    return cast( int )luaL_checkinteger( L, n );
-}
-int luaL_optint( lua_State* L, int n, lua_Integer d ) {
-    return cast( int )luaL_optinteger( L, n, d );
-}
-long luaL_checklong( lua_State* L, int n ) {
-    return luaL_checkinteger( L, n );
-}
-long luaL_optlong( lua_State* L, int n, lua_Integer d ) {
-    return luaL_optinteger( L, ( n ), ( d ) );
 }
 const( char )* luaL_typename( lua_State* L, int i ) {
     return lua_typename( L, lua_type( L,i ) );
@@ -164,9 +164,7 @@ int luaL_loadbuffer( lua_State* L, const( char )* s, size_t sz, const( char )* n
   ( ( void )( ( B )->n < ( B )->size || luaL_prepbuffsize( ( B ), 1 ) ), \
    ( ( B )->b[( B )->n++] = ( c ) ) )
 #define luaL_addsize( B,s )   ( ( B )->n += ( s ) )*/
-void luaL_register( lua_State* L, const( char )* n, const( luaL_Reg )* l ) {
-    luaL_openlib( L, n, l, 0 );
-}
+
 //luaconf.h
 /*#define luai_writestring( s,l ) fwrite( ( s ), sizeof( char ), ( l ), stdout )
 #define luai_writeline()    ( luai_writestring( "\n", 1 ), fflush( stdout ) )

--- a/source/derelict/lua/types.d
+++ b/source/derelict/lua/types.d
@@ -27,16 +27,18 @@ DEALINGS IN THE SOFTWARE.
 */
 module derelict.lua.types;
 
+private import std.c.stdio : FILE;
+
 //lua.h
 // The minimum version of Lua with which this binding is compatible.
 enum LUA_VERSION_MAJOR ="5";
-enum LUA_VERSION_MINOR ="2";
-enum LUA_VERSION_NUM = 502;
+enum LUA_VERSION_MINOR ="3";
+enum LUA_VERSION_NUM = 503;
 enum LUA_VERSION_RELEASE = "0";
 
 enum LUA_VERSION = "Lua " ~ LUA_VERSION_MAJOR ~ "." ~ LUA_VERSION_MINOR;
 enum LUA_RELEASE = LUA_VERSION ~ "." ~ LUA_VERSION_RELEASE;
-enum LUA_COPYRIGHT = LUA_RELEASE ~ "  Copyright ( C ) 1994-2012 Lua.org, PUC-Rio";
+enum LUA_COPYRIGHT = LUA_RELEASE ~ "  Copyright (C) 1994-2015 Lua.org, PUC-Rio";
 enum LUA_AUTHORS = "R. Ierusalimschy, L. H. de Figueiredo, W. Celes";
 
 enum LUA_SIGNATURE = "\033Lua";
@@ -62,6 +64,7 @@ struct lua_State;
 
 extern( C ) nothrow {
     alias lua_CFunction = int function( lua_State* L );
+    alias lua_KFunction = int function( lua_State* L, int status, lua_KContext ctx );
     alias lua_Reader = const( char )* function( lua_State* L, void* ud, size_t* sz );
     alias lua_Writer = int function( lua_State* L, const( void )* p, size_t sz, void* ud );
     alias lua_Alloc = void* function( void* ud, void* ptr, size_t osize, size_t nsize );
@@ -88,19 +91,27 @@ enum {
 }
 
 alias lua_Number = double;
-alias lua_Integer = ptrdiff_t;
-alias lua_Unsigned = uint;
+alias lua_Integer = long;
+alias lua_Unsigned = ulong;
+alias lua_KContext = ptrdiff_t;
 
 enum {
     LUA_OPADD = 0,
     LUA_OPSUB = 1,
     LUA_OPMUL = 2,
-    LUA_OPDIV = 3,
-    LUA_OPMOD = 4,
-    LUA_OPPOW = 5,
-    LUA_OPUNM = 6,
+    LUA_OPMOD = 3,
+    LUA_OPPOW = 4,
+    LUA_OPDIV = 5,
+    LUA_OPIDIV= 6,
+    LUA_OPBAND= 7,
+    LUA_OPBOR = 8,
+    LUA_OPBXOR= 9,
+    LUA_OPSHL = 10,
+    LUA_OPSHR = 11,
+    LUA_OPUNM = 12,
+    LUA_OPBNOT= 13,
 
-    LUA_OPWQ = 0,
+    LUA_OPEQ = 0,
     LUA_OPLT = 1,
     LUA_OPLE = 2,
 
@@ -112,10 +123,7 @@ enum {
     LUA_GCSTEP = 5,
     LUA_GCSETPAUSE = 6,
     LUA_GCSETSTEPMUL = 7,
-    LUA_GCSETMAJORINC = 8,
     LUA_GCISRUNNING = 9,
-    LUA_GCGEN = 10,
-    LUA_GCINC = 11,
 
     LUA_HOOKCALL = 0,
     LUA_HOOKRET = 1,
@@ -129,7 +137,25 @@ enum {
     LUA_MASKCOUNT = 1 << LUA_HOOKCOUNT,
 }
 
-struct lua_Debug;
+struct lua_Debug {
+    int event;
+    const(char*) name;
+    const(char*) namewhat;
+    const(char*) what;
+    const(char*) source;
+    int currentline;
+    int linedefined;
+    int lastlinedefined;
+    ubyte nups;
+    ubyte nparams;
+    byte isvararg;
+    byte istailcall;
+    char[LUA_IDSIZE] short_src;
+    // private
+    void* i_ci;
+}
+
+enum LUA_ERRFILE = LUA_ERRERR + 1;
 
 extern( C ) nothrow alias lua_Hook  = void function( lua_State*, lua_Debug* );
 
@@ -139,7 +165,7 @@ struct luaL_Reg {
     lua_CFunction func;
 }
 
-enum LUA_NOREF = -2;
+enum int LUA_NOREF = -2;
 enum int LUA_REFNIL = -1;
 
 struct luaL_Buffer {
@@ -147,10 +173,13 @@ struct luaL_Buffer {
     size_t size;
     size_t n;
     lua_State* L;
-    char initb[];
+    char[ (0x80 * (void*).sizeof * lua_Integer.sizeof) ] initb;
 }
 
-struct luaL_Stream;
+struct luaL_Stream {
+    FILE *f;
+    lua_CFunction closef;
+}
 
 //lualib.h
 enum : string {
@@ -159,6 +188,7 @@ enum : string {
     LUA_IOLIBNAME = "io",
     LUA_OSLIBNAME = "os",
     LUA_STRLIBNAME = "string",
+    LUA_UTF8LIBNAME = "utf8",
     LUA_BITLIBNAME = "bit32",
     LUA_MATHLIBNAME = "math",
     LUA_DBLIBNAME = "debug",
@@ -171,10 +201,13 @@ alias LUAI_UMEM = size_t;
 alias LUAI_MEM = ptrdiff_t;
 alias LUA_NUMBER = double;
 alias LUAI_UACNUMBER = double;
-alias LUA_INTEGER = ptrdiff_t;
-alias LUA_UNSIGNED = uint;
+alias LUA_INTEGER = long;
+alias LUA_UNSIGNED = ulong;
+alias LUA_KCONTEXT = ptrdiff_t;
 
 enum LUA_NUMBER_SCAN = "%lf";
 enum LUA_NUMBER_FMT = "%.14g";
 enum LUAI_MAXSTACK = 1000000;
 enum LUAI_FIRSTPSEUDOIDX = -LUAI_MAXSTACK - 1000;
+enum LUA_IDSIZE = 60;
+enum LUAI_MAXSHORTLEN = 40;


### PR DESCRIPTION
I've updated DerelictLua to Lua 5.3 (released at www.lua.org) (also updated the required DerelictUtil to the newest version). Small test apps compile&run but I don't have any big code piece to make sure everything is correctly translated. I went line by line through the header files, with the help of http://www.lua.org/manual/5.3/readme.html#changes . This supports only the non-changed lua build settings (64-bit integers&double precision). My Win64 MSVC2013 build of the lua dll: https://drive.google.com/folderview?id=0B5l6r6W7xAx-cGpLekFndE82OHM&usp=sharing.
I don't know how to make this SharedLibVersion-aware, so I just changed the main files. If that's not OK, you can close this PR.