### PR TITLE
D-style syntax warning

### DIFF
--- a/source/derelict/lua/types.d
+++ b/source/derelict/lua/types.d
@@ -147,7 +147,7 @@ struct luaL_Buffer {
     size_t size;
     size_t n;
     lua_State* L;
-    char initb[];
+    char[] initb;
 }
 
 struct luaL_Stream;


### PR DESCRIPTION
Warning: instead of C-style syntax, use D-style syntax 'char[] initb'