### PR TITLE
Added macOS libNames and missing nothrow/pure in macros.d

### DIFF
--- a/source/derelict/lua/lua.d
+++ b/source/derelict/lua/lua.d
@@ -39,6 +39,8 @@ private {
 
     static if(Derelict_OS_Windows) {
         enum libNames = "lua53.dll";
+    } else static if(Derelict_OS_Mac) {
+        enum libNames = "liblua.5.3.dylib";
     } else static if(Derelict_OS_Posix) {
         enum libNames = "liblua.so.5.3";
     }

--- a/source/derelict/lua/macros.d
+++ b/source/derelict/lua/macros.d
@@ -31,10 +31,10 @@ private {
     import derelict.lua.types;
 }
 
-@nogc:
+@nogc nothrow:
 
 //lua.h
-ptrdiff_t lua_getextraspace(lua_State* L) {
+ptrdiff_t lua_getextraspace(lua_State* L) pure {
     return cast(ptrdiff_t)(cast(void*)L - LUA_EXTRASPACE);
 }
 

--- a/source/derelict/lua/macros.d
+++ b/source/derelict/lua/macros.d
@@ -34,7 +34,7 @@ private {
 @nogc nothrow:
 
 //lua.h
-ptrdiff_t lua_getextraspace(lua_State* L) pure {
+ptrdiff_t lua_getextraspace(lua_State* L) {
     return cast(ptrdiff_t)(cast(void*)L - LUA_EXTRASPACE);
 }
 


### PR DESCRIPTION
Hello!

I made two small enhancements!

The first make it work with Lua 5.3 installed from Homebrew on macOS and the second adds missing annotations in macros.d.
