### PR TITLE
lua_Integer to 64-bit, lua_rawgeti() to use lua_Integer

### DIFF
--- a/source/derelict/lua/functions.d
+++ b/source/derelict/lua/functions.d
@@ -82,7 +82,7 @@ extern(C) @nogc nothrow {
     alias da_lua_getfield = int function(lua_State*, int, const(char)*);
     alias da_lua_geti = int function(lua_State*, int, lua_Integer);
     alias da_lua_rawget = int function(lua_State*, int);
-    alias da_lua_rawgeti = int function(lua_State*, int, int);
+    alias da_lua_rawgeti = int function(lua_State*, int, lua_Integer);
     alias da_lua_rawgetp = int function(lua_State*, int, const(void)*);
     alias da_lua_createtable = void function(lua_State*, int, int);
     alias da_lua_newuserdata = void* function(lua_State*, size_t);

--- a/source/derelict/lua/types.d
+++ b/source/derelict/lua/types.d
@@ -92,7 +92,7 @@ enum {
 }
 
 alias lua_Number = double;
-alias lua_Integer = ptrdiff_t;
+alias lua_Integer = long;
 alias lua_Unsigned = uint;
 alias lua_KContext = ptrdiff_t;
 alias LUA_NUMBER = lua_Number;


### PR DESCRIPTION
With "stock" settings, lua_Integer is 64-bit even in 32-bit machines. lua_rawgeti() argument n is lua_Integer.

This causes problems with 32-bit Windows builds, which use 32-bit stack ABI. For example, lua_rawgeti() is unable to return the values of references. For more information, see:

https://stackoverflow.com/questions/56036831/d-win32-lua-rawgeti-pushes-nil
